### PR TITLE
Allow editing the color string to specify the color.

### DIFF
--- a/src/ColorPickerWindow.vala
+++ b/src/ColorPickerWindow.vala
@@ -74,7 +74,7 @@ namespace ColorPicker {
             
             var format_entry = new Gtk.Entry ();
             format_entry.placeholder_text = ext_active_color.to_css_rgb_string ();
-            format_entry.set_editable (false);
+            format_entry.set_editable (true);
             format_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "edit-copy");     
             format_entry.margin_end = 6;
             
@@ -233,7 +233,21 @@ namespace ColorPicker {
             this.show.connect(() => {            
                 pick_color_button.clicked ();
             });
-                                  
+                           
+            format_entry.activate.connect (() => {
+                var color_string = format_entry.get_text ();
+                if (ext_active_color.parse (color_string)) {
+                    color_area.set_color (ext_active_color);
+                    color_area.queue_draw ();
+                                   
+                    hex_label.set_markup (ext_active_color.to_uppercase_hex_string ());
+
+                    color_history.add_color (ext_active_color);
+                                
+                    this.present ();
+                }
+                
+            });
             
         }
         


### PR DESCRIPTION
Hi!  I'm brand new to both elementary OS and Vala, so this pull request may be rubbish.  I'd love any pointers you may have as well.

I thought I'd try to tackle allowing a user to specify the color as a string and then displaying it in the app and the history.  This is done by allowing the user to edit the entry and parsing the color when the user presses `enter`.  If the value is a valid color, the color will be parsed and used.  If not, the action is ignored.

Here's an animated gif of the feature:

![ezgif com-crop](https://user-images.githubusercontent.com/2583646/35371126-883cc5cc-014f-11e8-8946-a586b2c86f6e.gif)

I noticed #30 while typing up this pull request.  I totally understand if you want to implement this a different way.  I'd be happy to try my hand at that as well (with some mentoring, if you can).

Thanks for an awesome project and a chance to learn Vala, GTK, and elementary OS!