### PR TITLE
mesonconf depreciated, use meson configure instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You'll need the following dependencies to build:
 Call in the project's root folder:
 
     meson build && cd build
-    mesonconf -Dprefix=/usr
+    meson configure -Dprefix=/usr
     ninja
     sudo ninja install
     com.github.ronnydo.colorpicker

--- a/dev-build.sh
+++ b/dev-build.sh
@@ -1,7 +1,7 @@
 sudo rm -r build
 meson build
 cd build
-mesonconf -Dprefix=/usr
+meson configure -Dprefix=/usr
 ninja
 ./com.github.ronnydo.colorpicker
 cd ..


### PR DESCRIPTION
```bash
➜ mesonconf -Dprefix=/usr
Error: This executable is no more. Use "meson configure" instead.
```

using `meson configure -Dprefix=/usr` fixes it