### PR TITLE
Fix deprecations

### DIFF
--- a/src/Widgets/ColorHistory.vala
+++ b/src/Widgets/ColorHistory.vala
@@ -180,7 +180,7 @@ namespace ColorPicker.Widgets {
             ctx.rel_line_to (triangle_width / 2, -1 * triangle_height);
             ctx.rel_line_to (triangle_width / 2, triangle_height);
             ctx.close_path ();                                     
-            Gdk.cairo_set_source_rgba (ctx, style_context.get_background_color(Gtk.StateFlags.NORMAL));            
+            Gdk.cairo_set_source_rgba (ctx, style_context.get_color (Gtk.StateFlags.NORMAL));            
             ctx.fill ();   
            
             


### PR DESCRIPTION
Fixes these warnings on compile:

```
../src/Widgets/ColorHistory.vala:183.45-183.78: warning: Gtk.StyleContext.get_background_color has been deprecated since 3.16
../src/Widgets/Picker.vala:76.31-76.46: warning: Gdk.Screen.get_width has been deprecated since 3.22
../src/Widgets/Picker.vala:76.52-76.68: warning: Gdk.Screen.get_height has been deprecated since 3.22
../src/Widgets/Picker.vala:135.14-135.24: warning: Gtk.Widget.get_pointer has been deprecated since 3.4
../src/Widgets/Picker.vala:223.27-223.71: warning: Gdk.Display.get_device_manager has been deprecated since 3.20.
../src/Widgets/Picker.vala:224.13-224.38: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/Picker.vala:224.13-224.46: warning: Gdk.Device.grab has been deprecated since 3.20.
../src/Widgets/Picker.vala:245.13-245.23: warning: Gtk.Widget.get_pointer has been deprecated since 3.4
../src/Widgets/Picker.vala:246.27-246.71: warning: Gdk.Display.get_device_manager has been deprecated since 3.20.
../src/Widgets/Picker.vala:257.21-257.46: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/Picker.vala:260.21-260.46: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/Picker.vala:263.21-263.46: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/Picker.vala:266.21-266.46: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/Picker.vala:301.27-301.71: warning: Gdk.Display.get_device_manager has been deprecated since 3.20.
../src/Widgets/Picker.vala:302.27-302.52: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/Picker.vala:306.26-306.37: warning: Gdk.Device.grab has been deprecated since 3.20.
../src/Widgets/Picker.vala:314.17-314.30: warning: Gdk.Device.ungrab has been deprecated since 3.20.
../src/Widgets/Picker.vala:321.26-321.38: warning: Gdk.Device.grab has been deprecated since 3.20.
../src/Widgets/Picker.vala:329.21-329.35: warning: Gdk.Device.ungrab has been deprecated since 3.20.
Compilation succeeded - 19 warning(s)
```
